### PR TITLE
Add executables to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Executables
+*
+!*.*
+!LICENSE


### PR DESCRIPTION
Adds executables (like `diceware`) to gitignore.